### PR TITLE
Export macro assert_files_equal

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -114,3 +114,59 @@ mod test_assert_complex_array_relative_eq {
         assert_complex_array_relative_eq!(expected, result);
     }
 }
+
+/// Assert two files on disk are equal
+///
+/// This macro reads the files to a string and
+/// compares them. If one or both files do not exist,
+/// the assert fails.
+#[macro_export]
+macro_rules! assert_files_equal {
+    ($lhs:expr, $rhs:expr) => {
+        let left = std::fs::read_to_string($lhs).expect("Unable to read file `$lhs`");
+        let right = std::fs::read_to_string($rhs).expect("Unable to read file `$rhs`");
+
+        assert_eq!(left, right);
+    };
+}
+
+#[cfg(test)]
+mod test_assert_files_equal {
+    use std::path::PathBuf;
+
+    fn data_directory() -> PathBuf {
+        let mut path_buf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path_buf.push("tests");
+        path_buf.push("regression_files");
+        path_buf
+    }
+
+    fn filename1() -> PathBuf {
+        let mut path_buf = data_directory();
+        path_buf.push("display_memory.cti");
+        path_buf
+    }
+
+    fn filename2() -> PathBuf {
+        let mut path_buf = data_directory();
+        path_buf.push("wvi_file.cti");
+        path_buf
+    }
+
+    #[test]
+    fn pass_on_same_file() {
+        assert_files_equal!(filename1(), filename1());
+    }
+
+    #[test]
+    #[should_panic]
+    fn fail_on_different_files() {
+        assert_files_equal!(filename1(), filename2());
+    }
+
+    #[test]
+    #[should_panic]
+    fn fail_on_bad_path() {
+        assert_files_equal!(filename1(), "");
+    }
+}

--- a/tests/regression_tests.rs
+++ b/tests/regression_tests.rs
@@ -1,6 +1,6 @@
 use citi::{
-    assert_array_relative_eq, assert_complex_array_relative_eq, DataArray, Device, Record, Result,
-    Var,
+    assert_array_relative_eq, assert_complex_array_relative_eq, assert_files_equal, DataArray,
+    Device, Record, Result, Var,
 };
 use num_complex::Complex;
 use std::fs::File;
@@ -567,56 +567,6 @@ mod cti_read_regression_tests {
                 e => panic!("{:?}", e),
             }
         }
-    }
-}
-
-macro_rules! assert_files_equal {
-    ($lhs:expr, $rhs:expr) => {
-        let left = std::fs::read_to_string($lhs).expect("Unable to read file `$lhs`");
-        let right = std::fs::read_to_string($rhs).expect("Unable to read file `$rhs`");
-
-        assert_eq!(left, right);
-    };
-}
-
-#[cfg(test)]
-mod test_assert_files_equal {
-    use super::*;
-
-    fn data_directory() -> PathBuf {
-        let mut path_buf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path_buf.push("tests");
-        path_buf.push("regression_files");
-        path_buf
-    }
-
-    fn filename1() -> PathBuf {
-        let mut path_buf = data_directory();
-        path_buf.push("display_memory.cti");
-        path_buf
-    }
-
-    fn filename2() -> PathBuf {
-        let mut path_buf = data_directory();
-        path_buf.push("wvi_file.cti");
-        path_buf
-    }
-
-    #[test]
-    fn pass_on_same_file() {
-        assert_files_equal!(filename1(), filename1());
-    }
-
-    #[test]
-    #[should_panic]
-    fn fail_on_different_files() {
-        assert_files_equal!(filename1(), filename2());
-    }
-
-    #[test]
-    #[should_panic]
-    fn fail_on_bad_path() {
-        assert_files_equal!(filename1(), "");
     }
 }
 


### PR DESCRIPTION
Simply exports the macro `assert_files_equal` so it can be used in other crates.