### PR TITLE
Array macros take by reference

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -7,11 +7,14 @@
 #[macro_export]
 macro_rules! assert_array_relative_eq {
     ($lhs:expr, $rhs:expr) => {
+        let left = &$lhs;
+        let right = &$rhs;
+
         // Size
-        assert_eq!($lhs.len(), $rhs.len());
+        assert_eq!(left.len(), right.len());
 
         // Values
-        let it = $lhs.iter().zip($rhs.iter());
+        let it = left.iter().zip(right.iter());
         for (l, r) in it {
             approx::assert_relative_eq!(l, r);
         }
@@ -60,11 +63,14 @@ mod test_assert_array_relative_eq_macro {
 #[macro_export]
 macro_rules! assert_complex_array_relative_eq {
     ($lhs:expr, $rhs:expr) => {
+        let left = &$lhs;
+        let right = &$rhs;
+
         // Size
-        assert_eq!($lhs.len(), $rhs.len());
+        assert_eq!(left.len(), right.len());
 
         // Values
-        for (l, r) in $lhs.iter().zip($rhs.iter()) {
+        for (l, r) in left.iter().zip(right.iter()) {
             approx::assert_relative_eq!(l.re, r.re);
             approx::assert_relative_eq!(l.im, r.im);
         }


### PR DESCRIPTION
A nuanced fix to the macros, but helps keep tests clean. It allows us to pass function outputs to the macro. Modified `assert_array_relative_eq` and `assert_complex_array_relative_eq`. Allows us to run tests like:

```rust
assert_array_relative_eq!(vec![], create_vector());
```

while still being able to run tests like:
```rust
let result = vec![];
let expected = create_vector();
assert_array_relative_eq!(result, expected);
```
